### PR TITLE
Added saving server configs to server database as well as locally to the bot

### DIFF
--- a/commands/system/set.js
+++ b/commands/system/set.js
@@ -11,7 +11,7 @@
 // OR the same as:
 // const [action, key, ...value] = args;
 const { codeBlock } = require("@discordjs/builders");
-const { settings } = require("../../modules/settings.js");
+const settings = require("../../modules/settings.js");
 const { awaitReply } = require("../../modules/functions.js");
 
 exports.run = async (client, message, [action, key, ...value], level) => { // eslint-disable-line no-unused-vars
@@ -35,9 +35,6 @@ exports.run = async (client, message, [action, key, ...value], level) => { // es
     // User must specify a different value than the current one.
     if (joinedValue === serverSettings[key]) return message.reply({ content: "This setting already has that value!", allowedMentions: { repliedUser: (replying === "true") }});
     
-    // If the guild does not have any overrides, initialize it.
-    if (!settings.has(message.guild.id)) settings.set(message.guild.id, {});
-
     // Modify the guild overrides directly.
     settings.set(message.guild.id, joinedValue, key);
 

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -18,7 +18,7 @@ module.exports = async (client, message) => {
   const settings = message.settings = getSettings(message.guild);
 
   //Ignore any channel which isn't #testing, EXCEPT DMs
-  if (message.guild === null || message.guild.id !== "953924192259170335") return;
+  // if (message.guild === null || message.guild.id !== "953924192259170335") return;
 
   // Checks if the bot was mentioned via regex, with no message after it,
   // returns the prefix. The reason why we used regex here instead of

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -17,9 +17,6 @@ module.exports = async (client, message) => {
   // If there is no guild, get default conf (DMs)
   const settings = message.settings = getSettings(message.guild);
 
-  //Ignore any channel which isn't #testing, EXCEPT DMs
-  // if (message.guild === null || message.guild.id !== "953924192259170335") return;
-
   // Checks if the bot was mentioned via regex, with no message after it,
   // returns the prefix. The reason why we used regex here instead of
   // message.mentions is because of the mention prefix later on in the

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -1,6 +1,6 @@
 const logger = require("./logger.js");
 const config = require("../config.js");
-const { settings } = require("./settings.js");
+const settings = require("./settings.js");
 // Let's start by getting some useful functions that we'll use throughout
 // the bot, like logs and elevation features.
 

--- a/modules/functions.js
+++ b/modules/functions.js
@@ -1,8 +1,6 @@
 const logger = require("./logger.js");
 const config = require("../config.js");
 const settings = require("./settings.js");
-// Let's start by getting some useful functions that we'll use throughout
-// the bot, like logs and elevation features.
 
 /**
   PERMISSION LEVEL FUNCTION

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -42,7 +42,11 @@ class Settings {
 
     let body = { serverId: guild };
     body[key] = value;
-    axios.put(`${process.env.API_URL}/v1/config/setConfig`, body, { api_key: process.env.API_KEY })
+    axios.put(`${process.env.API_URL}/v1/config/setConfig`, body, { 
+      headers: {
+        api_key: process.env.API_KEY 
+      }
+    })
     .then(res => {
       return this.client.set(guild, value, key);
     }
@@ -62,7 +66,11 @@ class Settings {
   }
 
   delete(guild) {
-    axios.delete(`${process.env.API_URL}/v1/config/deleteServerConfig`, { serverId: guild }, { api_key: process.env.API_KEY })
+    axios.delete(`${process.env.API_URL}/v1/config/deleteServerConfig`, { serverId: guild }, { 
+      headers: {
+        api_key: process.env.API_KEY 
+      }
+    })
     .then(res => {
       this.client.delete(guild);
     })

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -1,9 +1,75 @@
+require('dotenv').config();
+const axios = require("axios");
 const Enmap = require("enmap");
+
 // Now we integrate the use of Evie's awesome Enmap module, which
 // essentially saves a collection to disk. This is great for per-server configs,
 // and makes things extremely easy for this purpose.
-module.exports = {
-  settings: new Enmap({
-    name: "settings",
-  }),
-};
+
+class Settings {
+  constructor() {
+    this.client = new Enmap({
+      name: "settings"
+    });
+
+    // Get all the configs from the API and set them in enmap.
+    axios.get(`${process.env.API_URL}/v1/config/`, {
+      headers: {
+        api_key: process.env.API_KEY
+      }
+    })
+      .then(res => {
+        res.data.data.forEach(config => {
+          this.client.set(config.serverId, config);
+        });
+      });
+
+
+  }
+
+  get(guild) {
+    return this.client.get(guild);
+  }
+
+  set(guild, value, key) {
+    // Check if the guild is set as "default", if so then we only want to set it in enmap
+    // if it is not already set.
+    if (guild === "default") {
+      return this.client.set("default", value, key);
+    }
+
+    // Set the settings on the API as well as the local enmap.
+
+    let body = { serverId: guild };
+    body[key] = value;
+    axios.put(`${process.env.API_URL}/v1/config/setConfig`, body, { api_key: process.env.API_KEY })
+    .then(res => {
+      return this.client.set(guild, value, key);
+    }
+    ).catch(err => {
+      console.log(err.response.data);
+    });
+
+  }
+
+  // This is the same as the set command, but it will only set the value if it is not already set.
+  ensure(guild, value) {
+    this.set(guild, value);
+  }
+
+  has(guild) {
+    return this.client.has(guild);
+  }
+
+  delete(guild) {
+    axios.delete(`${process.env.API_URL}/v1/config/deleteServerConfig`, { serverId: guild }, { api_key: process.env.API_KEY })
+    .then(res => {
+      this.client.delete(guild);
+    })
+    .catch(err => {
+      console.log(err.response.data);
+    });
+  }
+}
+
+module.exports = new Settings();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
Instead of having the code interact with enmap directly, I made a class that imitates all the functions of enmap but before setting anything to push it to the API. It also gets all the current configs from the API and stores them locally. This will need to be changed if we decide to shard the bot.

**Semantic versioning classification:**

- [x] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
