### PR TITLE
Fixing guide typo

### DIFF
--- a/slash/skilltree/guide.js
+++ b/slash/skilltree/guide.js
@@ -44,7 +44,7 @@ async function getPages() {
       "- If you accidently completed a skill, or want to start again. Use `/completed` to view "+
       "completed skills and erase their data. Removing their XP."),
     new Page("Setup", setupLogo,
-      "To use Skill Tree, you need to create an account with `/setup`" +
+      "To use Skill Tree, you need to create an account with `/setup` " +
       "this will automatically be cross compatible with the skill tree app. "+
       "You need to set a few options to use the skill tree: \n\n"+
       "**DIFFICULTY**: Sets difficulty level of your starting skills. You can "+

--- a/slash/skilltree/setup.js
+++ b/slash/skilltree/setup.js
@@ -205,6 +205,6 @@ exports.commandData = {
   name: "setup",
   description: "Sets up your Skill Tree account",
   options: [],
-  defaultPermission: false,
+  defaultPermission: true,
   category: "Skill Tree",
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
The /guide command would show /setupthis as the command to be run instead of /setup. The PR adds the missing space.


**Semantic versioning classification:**

- [ ] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to README, etc.
