### PR TITLE
Fix command prefix for some help messages

### DIFF
--- a/slash/skilltree/start.js
+++ b/slash/skilltree/start.js
@@ -26,7 +26,7 @@ async function startMenu(client, interaction, userID) {
 
   if (available.length === 0) {
     await interaction
-      .editReply("```You have no available skills. Use ~tasks to see what skills you have started```");
+      .editReply("```You have no available skills. Use /tasks to see what skills you have started```");
     return;
   }
   //Create panel showing skills

--- a/slash/skilltree/taskList.js
+++ b/slash/skilltree/taskList.js
@@ -26,7 +26,7 @@ exports.run = async (client, interaction) => {
   const [tasks, timezoneOffset] = await getCurrentTasks(userID);
   if (tasks.length === 0) {
     await interaction
-      .editReply("```No Current tasks, go to `~start` to start a skill```");
+      .editReply("```No current tasks. Use /start to start a new skill```");
   } else {
     //Show tasks in embed
     createTaskList(client, interaction, tasks, userID, timezoneOffset);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**
Makes the / prefix consistent for help messages (previously some had ~ instead). Also fixes the grammar of a help message.
Resolves #109 
**Semantic versioning classification:**

- [ ] This PR changes the framework's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to README, etc. 

